### PR TITLE
実績一覧のエラーハンドリング

### DIFF
--- a/src/store/modules/achievement/index.js
+++ b/src/store/modules/achievement/index.js
@@ -14,7 +14,11 @@ export default {
   /* eslint-enable no-param-reassign */
   actions: {
     async getAchievements({ commit }, sessionID) {
-      commit('setAchievements', await achievementClient.getAchievements(sessionID));
+      try {
+        commit('setAchievements', await achievementClient.getAchievements(sessionID));
+      } catch (e) {
+        commit('criticalError/createError', e, { root: true });
+      }
     },
   },
 };


### PR DESCRIPTION
merge into #71 
`GET /achievements` でエラーが出るのはやばいのでcriticalError