### PR TITLE
Open external website with new window

### DIFF
--- a/src/components/AchievementsList.vue
+++ b/src/components/AchievementsList.vue
@@ -1,7 +1,7 @@
 <template>
   <ul>
     <li v-for="item in achievements" :key="item.id">
-      <a v-bind:href="item.url">
+      <a v-bind:href="item.url" target="_blank">
         <Achievement :achievement="item"/>
       </a>
     </li>


### PR DESCRIPTION
# Summary
戦績一覧のリンクは外部サイトにつながることを前提としているのでtarget="_blank"にした

ユーザーページからGitHub開くときとかは新規タブしてるので統一したい