### PR TITLE
Justify height of .achievement

### DIFF
--- a/src/components/Achievement.vue
+++ b/src/components/Achievement.vue
@@ -46,6 +46,18 @@ div.achievement:hover {
 div.achievement:hover dd.year {
   color: inherit;
 }
+div.achievement::after{
+  display: block;
+  content: "";
+  height: 30px;
+  width: 100%;
+  position: absolute;
+  bottom: 250px;
+  background: linear-gradient(rgba(255,255,255,0),rgba(255,255,255,1));
+}
+div.achievement:hover::after{
+  opacity: 0;
+}
 p {
   text-overflow: ellipsis;
 }
@@ -85,16 +97,6 @@ dd.year {
   transform-origin: right top;
   line-height: 1;
   font-family: "Barlow";
-}
-dd.desc:after{
-  display: block;
-  content: "";
-  height: 30px;
-  width: calc(100% + 40px);
-  margin: 0 -20px;
-  position: absolute;
-  bottom: 0;
-  background: linear-gradient(rgba(255,255,255,0),rgba(255,255,255,1));
 }
 .members {
   display: hidden;

--- a/src/components/Achievement.vue
+++ b/src/components/Achievement.vue
@@ -55,10 +55,11 @@ img {
   object-fit: cover;
   position: relative;
   z-index: 2;
+  background: white;
 }
 dl {
   margin: 20px 20px 0;
-  height: 130px;
+  height: 150px;
   position: relative;
 }
 dt {

--- a/src/components/Achievement.vue
+++ b/src/components/Achievement.vue
@@ -4,7 +4,7 @@
       <dt>{{ achievement.title }}</dt>
       <dd class="award">{{ achievement.award }}</dd>
       <dd class="year">{{ year }}</dd>
-      <dd>{{ achievement.description }}</dd>
+      <dd class="desc">{{ achievement.description }}</dd>
       <dd class="members" v-if="achievement.members.length">
         <ul>
           <p>参加メンバー</p>
@@ -84,6 +84,16 @@ dd.year {
   transform-origin: right top;
   line-height: 1;
   font-family: "Barlow";
+}
+dd.desc:after{
+  display: block;
+  content: "";
+  height: 30px;
+  width: calc(100% + 40px);
+  margin: 0 -20px;
+  position: absolute;
+  bottom: 0;
+  background: linear-gradient(rgba(255,255,255,0),rgba(255,255,255,1));
 }
 .members {
   display: hidden;

--- a/src/components/Achievement.vue
+++ b/src/components/Achievement.vue
@@ -73,6 +73,7 @@ dl {
   margin: 20px 20px 0;
   height: 150px;
   position: relative;
+  overflow: hidden;
 }
 dt {
   font-size: 1.4rem;

--- a/src/components/Achievement.vue
+++ b/src/components/Achievement.vue
@@ -4,7 +4,7 @@
       <dt>{{ achievement.title }}</dt>
       <dd class="award">{{ achievement.award }}</dd>
       <dd class="year">{{ year }}</dd>
-      <dd class="desc">{{ achievement.description }}</dd>
+      <dd>{{ achievement.description }}</dd>
       <dd class="members" v-if="achievement.members.length">
         <ul>
           <p>参加メンバー</p>

--- a/src/components/Achievement.vue
+++ b/src/components/Achievement.vue
@@ -51,9 +51,15 @@ p {
 }
 img {
   width: 100%;
+  height: 250px;
+  object-fit: cover;
+  position: relative;
+  z-index: 2;
 }
 dl {
-  margin: 20px;
+  margin: 20px 20px 0;
+  height: 130px;
+  position: relative;
 }
 dt {
   font-size: 1.4rem;
@@ -91,9 +97,6 @@ dd.year {
   transition: ease-in-out 0.2s;
 }
 div.achievement:hover .members {
-  position: absolute;
-  padding: 20px;
-  border-radius: 8px;
   opacity: 0.95;
 }
 .members ul {

--- a/src/components/Achievement.vue
+++ b/src/components/Achievement.vue
@@ -98,6 +98,9 @@ dd.desc:after{
 .members {
   display: hidden;
   position: absolute;
+  bottom: -240px;
+  z-index: 3;
+  width: 100%;
   background-color: #222;
   color: white;
   padding: 20px;


### PR DESCRIPTION
# Changes
## dlの高さを揃えて溢れるぶんは殺す
* div.achievement にafter疑似要素を設定、non-hoverのときは白グラデがかかる
  * hover時もいい感じのグラデをかけたいけど linear-gradient に transition が効かないのでなんらかの策を考える必要がある
## imgの高さを揃え中央cropする
* object-fit は文明
## 参加メンバー表示位置の変更
* hover時に下ベースで位置を設定した
## 以下蛇足
* 省略した分のdescriptionも全文読めるようにモーダルを出すといいかもしれない？
* a要素の中にa要素は入れてはならない(=HTMLとして適切でない)のもあるので個人的にはモーダル作るのを推したい