### PR TITLE
戦歴のメンバー一覧の位置が揃っていなかったので修正

### DIFF
--- a/src/components/Achievement.vue
+++ b/src/components/Achievement.vue
@@ -103,7 +103,7 @@ dd.year {
   z-index: 3;
   background-color: #222;
   color: white;
-  top: 170px;
+  top: 150px;
   padding: 20px;
   margin-top: 40px;
   border-radius: 8px;

--- a/src/components/Achievement.vue
+++ b/src/components/Achievement.vue
@@ -103,6 +103,7 @@ dd.year {
   z-index: 3;
   background-color: #222;
   color: white;
+  top: 170px;
   padding: 20px;
   margin-top: 40px;
   border-radius: 8px;


### PR DESCRIPTION
戦歴のメンバー一覧の位置が、戦歴の題名、賞、説明の長さに影響を受けてしまうため修正