### PR TITLE
名前の右にスペースが空かないようにした

### DIFF
--- a/src/components/Achievement.vue
+++ b/src/components/Achievement.vue
@@ -9,9 +9,7 @@
         <ul>
           <p>参加メンバー</p>
           <li v-for="member in achievement.members" :key="member.member_id">
-            <router-link :to="{ name: 'profile' , params: { name: member.name } }">
-              {{ member.display_name || member.name }}
-            </router-link>
+            <router-link :to="{ name: 'profile' , params: { name: member.name } }">{{ member.display_name || member.name }}</router-link>
           </li>
         </ul>
       </dd>

--- a/src/components/Achievement.vue
+++ b/src/components/Achievement.vue
@@ -9,6 +9,7 @@
         <ul>
           <p>参加メンバー</p>
           <li v-for="member in achievement.members" :key="member.member_id">
+            <!-- eslint-disable-next-line max-len -->
             <router-link :to="{ name: 'profile' , params: { name: member.name } }">{{ member.display_name || member.name }}</router-link>
           </li>
         </ul>


### PR DESCRIPTION
#235 
元の現象は、macOS の Safari と、
iOS の Safari、 Chrome とかの WebView で描画されるブラウザでしか確認できない

閉じタグとテキストの間に改行が挿入されることで発生している
そのまま修正すると行が100文字を超えるため es lint disable を入れている
(他にいい方法あったら教えてください......タグの中で改行する、という方法もあるけど、ちょっとダサいかな...と思ったのでやめた)